### PR TITLE
fix: support --watch mode of cem analyzer by clearing global variables

### DIFF
--- a/.changeset/little-llamas-think.md
+++ b/.changeset/little-llamas-think.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/cem-inheritance": patch
+---
+
+support --watch mode of cem analyzer by clearing global variables

--- a/src/inheritance.ts
+++ b/src/inheritance.ts
@@ -29,6 +29,12 @@ export function updateCemInheritance(
     log.yellow("[cem-inheritance] - Skipped");
     return;
   }
+  // Reset states to support watch mode
+  completedClasses.clear();
+  classQueue = [];
+  cemEntities = [];
+  externalComponents = [];
+  externalMixins = [];
 
   log.log("[cem-inheritance] - Updating Custom Elements Manifest...");
   const newCem = generateUpdatedCem(cem, options);


### PR DESCRIPTION
When using `cem analyze --watch` everything works fine at first run, but subsequent runs simply omit inheritances because of component is not added to the `classQueue` due to guard clause here: https://github.com/wc-toolkit/cem-inheritance/blob/main/src/inheritance.ts#L151

This PR fixes it by clearing the global variables, ensuring everything is reloaded.

One other alternative could be to change the above guard clause to 
```ts
  if (!component) {
    return;
  } else if (completedClasses.has(component.name)) {
    classQueue.push(component);
    return;
  }
```
But this would miss the case were the definition of the parent changes (or any external CEM changes)